### PR TITLE
ci: Replace hub with gh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,14 +7,9 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-
-      - name: Install github/hub
-        run: |
-          export HUB_VERSION="2.14.2"
-          curl -fsSL https://github.com/github/hub/raw/8d91904208171b013f9a9d1175f4ab39068db047/script/get | bash -s "${HUB_VERSION}"
 
       - name: Install nkf
         run: |

--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ RELEASE_ASSETS_DIR="build"
 RELEASE_NOTES="release_notes.md"
 
 
-\rm -rf "${RELEASE_ASSETS_DIR}" || true
+rm -rf "${RELEASE_ASSETS_DIR}" || true
 mkdir "${RELEASE_ASSETS_DIR}"
 (
   cd ./dict
@@ -33,10 +33,7 @@ mkdir "${RELEASE_ASSETS_DIR}"
 
 sed -i "1iIME 拡張辞書 ${TAG_NAME}\n" "./${RELEASE_NOTES}"
 
-(
-  cd "${RELEASE_ASSETS_DIR}"
-  hub release edit \
-    --file "../${RELEASE_NOTES}" \
-    $(for i in $(echo *); do echo -n "--attach ${i}#${i} "; done) \
-    "${TAG_NAME}"
-)
+gh release delete --yes "${TAG_NAME}"
+gh release create "${TAG_NAME}" \
+  --notes-file "./${RELEASE_NOTES}" \
+  "${RELEASE_ASSETS_DIR}"/*


### PR DESCRIPTION
The reason to use `gh release delete` is here: https://github.com/cli/cli/issues/1997